### PR TITLE
General Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ That being said, instead of using the classic `set path+=**` hack to allow VIM t
 
 -   If not in a git project, it'll simply use the the current directory `.gitignore`
 -   If no `.gitignore` is available, it'll populate the `&path` but not using `**`
--   Deeply nested `.gitignore` are simply ignored
+-   Deeply nested `.gitignore` in a git project are simply ignored
 -   The classic `!` char is also ignored (otherwise some heavy logic would be required)
 
 ## Install
@@ -42,7 +42,8 @@ packloadall
 #### [Vundle.vim](https://github.com/VundleVim/Vundle.vim)
 
 ```vim
-call vundle#begin()
+call vundle#begin('~/.vim/plugged')
+Plugin 'VundleVim/Vundle.vim'
 Plugin 'Guergeiro/clean-path.vim'
 call vundle#end()
 ```
@@ -50,7 +51,7 @@ call vundle#end()
 #### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-call plug#begin()
+call plug#begin('~/.vim/plugged')
 Plug 'Guergeiro/clean-path.vim'
 call plug#end()
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ That being said, instead of using the classic `set path+=**` hack to allow VIM t
 
 #### Notes
 
--   If not in a git project, it'll add all files and directories from the current location, but not using `**`
+-   If not in a git project, it'll simply use the the current directory `.gitignore`
+-   If no `.gitignore` is available, it'll populate the `&path` but not using `**`
 -   Deeply nested `.gitignore` are simply ignored
 -   The classic `!` char is also ignored (otherwise some heavy logic would be required)
 

--- a/plugin/clean-path.vim
+++ b/plugin/clean-path.vim
@@ -33,8 +33,8 @@ function! s:BuildString(line) abort
     return a:line
 endfunction
 
-function! s:WildignoreString(gitPath) abort
-    let gitignore = a:gitPath . "/.gitignore"
+function! s:WildignoreString(dirPath) abort
+    let gitignore = a:dirPath . "/.gitignore"
     if !filereadable(gitignore)
         return ""
     endif
@@ -48,7 +48,7 @@ function! s:WildignoreString(gitPath) abort
         if line =~ '^!'   | con | endif
         if line =~ '^\s$' | con | endif
 
-        let igstring .= "," . a:gitPath . "/" . s:BuildString(line)
+        let igstring .= "," . a:dirPath . "/" . s:BuildString(line)
     endfor
 
     return substitute(igstring, '^,', '', "g")
@@ -57,13 +57,15 @@ endfunction
 function! s:SetPathFromGit() abort
     let gitDir = system("git rev-parse --show-toplevel")
     let gitDir = substitute(gitDir, "\n", "", "g")
+    let curDir = getcwd()
 
     let ignored = ""
-    if stridx(gitDir, "fatal") == -1
+    if stridx(curDir, gitDir) != -1
         " In Git Dir
         let ignored .= s:WildignoreString(gitDir)
     else
-        let gitDir = getcwd()
+        let gitDir = curDir
+        let ignored .= s:WildignoreString(gitDir)
     endif
 
     let l:findString = "find " . gitDir . " -maxdepth 1"

--- a/plugin/clean-path.vim
+++ b/plugin/clean-path.vim
@@ -60,7 +60,6 @@ function! s:SetPathFromGit() abort
     let curDir = getcwd()
 
     let ignored = ""
-    echo gitDir
     if gitDir != ""
         " In Git Dir
         let ignored .= s:WildignoreString(gitDir)

--- a/plugin/clean-path.vim
+++ b/plugin/clean-path.vim
@@ -60,7 +60,8 @@ function! s:SetPathFromGit() abort
     let curDir = getcwd()
 
     let ignored = ""
-    if stridx(curDir, gitDir) != -1
+    echo gitDir
+    if gitDir != ""
         " In Git Dir
         let ignored .= s:WildignoreString(gitDir)
     else
@@ -71,7 +72,7 @@ function! s:SetPathFromGit() abort
     let l:findString = "find " . gitDir . " -maxdepth 1"
 
     " Finds directories
-    let l:dirs = filter(systemlist(l:findString . " -type d"), {_,dir ->
+    let l:dirs = filter(systemlist(l:findString . " -type d -not -path " . gitDir), {_,dir ->
                 \ !empty(dir) && empty(filter(split(ignored, ','), {_,v -> v =~? dir[2:]}))
                 \ })
 


### PR DESCRIPTION
- Fixed odd case for systems that do not have git.
- Allowed to use `.gitignore` from current directory even though it's not on a git project.
- Fixed error that added ** to path.